### PR TITLE
Исправления и улучшения вкладок с машинами состояний

### DIFF
--- a/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachineDeleteModal.tsx
+++ b/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachineDeleteModal.tsx
@@ -7,7 +7,7 @@ import { Modal } from '@renderer/components/UI';
 import { useModelContext } from '@renderer/store/ModelContext';
 
 interface StateMachineDeleteModalProps {
-  data: StateMachineData;
+  data: StateMachineData | undefined;
   idx: string | undefined;
   isOpen: boolean;
   onClose: () => void;
@@ -34,6 +34,10 @@ export const StateMachineDeleteModal: React.FC<StateMachineDeleteModalProps> = (
     onSubmit();
     onClose();
   });
+  // если одна их этих переменных undefined, то значит, что-то пошло не так
+  if (data == undefined || idx == undefined) {
+    return;
+  }
   return (
     <Modal
       {...props}

--- a/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
+++ b/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
@@ -91,6 +91,7 @@ export const StateMachinesList: React.FC = () => {
         sideLabel="Удалить"
         platformList={platformList}
         isDuplicateName={isDuplicateName}
+        selectPlatformDisabled={true}
       />
       <StateMachineEditModal
         form={addProps.addForm}
@@ -102,6 +103,7 @@ export const StateMachinesList: React.FC = () => {
         sideLabel={undefined}
         platformList={platformList}
         isDuplicateName={isDuplicateName}
+        selectPlatformDisabled={false}
       />
       <StateMachineDeleteModal {...{ ...deleteProps, idx: selectedSm ?? undefined }} />
     </section>

--- a/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
+++ b/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
@@ -41,7 +41,7 @@ export const StateMachinesList: React.FC = () => {
     onRequestEditStateMachine,
     isDuplicateName,
   } = useStateMachines();
-  // TODO (Roundabout1): этот массив используется для теста, нужно будет доставать его из другого места
+
   const platformList = getAvailablePlatforms().map((platform) => {
     return { value: platform.idx, label: platform.name };
   });

--- a/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
+++ b/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
@@ -39,6 +39,7 @@ export const StateMachinesList: React.FC = () => {
     // onSwapStateMachines
     onRequestAddStateMachine,
     onRequestEditStateMachine,
+    isDuplicateName,
   } = useStateMachines();
   // TODO (Roundabout1): этот массив используется для теста, нужно будет доставать его из другого места
   const platformList = getAvailablePlatforms().map((platform) => {
@@ -89,6 +90,7 @@ export const StateMachinesList: React.FC = () => {
         onSide={editProps.onDelete}
         sideLabel="Удалить"
         platformList={platformList}
+        isDuplicateName={isDuplicateName}
       />
       <StateMachineEditModal
         form={addProps.addForm}
@@ -99,6 +101,7 @@ export const StateMachinesList: React.FC = () => {
         onSide={undefined}
         sideLabel={undefined}
         platformList={platformList}
+        isDuplicateName={isDuplicateName}
       />
       <StateMachineDeleteModal {...{ ...deleteProps, idx: selectedSm ?? undefined }} />
     </section>

--- a/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
+++ b/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
@@ -22,7 +22,7 @@ export const StateMachinesList: React.FC = () => {
       const controller = modelController.controllers[controllerId];
       if (!controller.stateMachinesSub[name] || !(controller.type === 'specific')) continue;
 
-      openTab({ type: 'editor', name: sM.name ?? name, canvasId: controller.id });
+      openTab({ type: 'editor', name: sM.name ? sM.name : name, canvasId: controller.id });
     }
   };
 

--- a/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
+++ b/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
@@ -39,7 +39,6 @@ export const StateMachinesList: React.FC = () => {
     // onSwapStateMachines
     onRequestAddStateMachine,
     onRequestEditStateMachine,
-    onRequestDeleteStateMachine,
   } = useStateMachines();
   // TODO (Roundabout1): этот массив используется для теста, нужно будет доставать его из другого места
   const platformList = getAvailablePlatforms().map((platform) => {
@@ -71,7 +70,7 @@ export const StateMachinesList: React.FC = () => {
               isSelected={id === selectedSm}
               onSelect={() => setSmSelected(id)}
               onEdit={() => onRequestEditStateMachine(id)}
-              onDelete={() => onRequestDeleteStateMachine(id)}
+              onDelete={() => undefined}
               onCallContextMenu={() => onCallContextMenu(id, sm)}
               // TODO: Доделать свап машин состояний
               onDragStart={() => console.log('setDragState')}

--- a/src/renderer/src/components/StateMachineEditModal.tsx
+++ b/src/renderer/src/components/StateMachineEditModal.tsx
@@ -56,15 +56,13 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
 
   const handleSubmit = hookHandleSubmit((data) => {
     if (isDuplicateName(data.name)) {
-      setError('name', { message: 'Имя не должно повторяться' });
+      setError('name', { message: 'Имя не должно повторять имена или ID других машин состояний' });
       return;
     }
     if (!data.platform) {
       setError('platform', { message: 'Выберите платформу' });
       return;
     }
-    //setError('name', { message: '' });
-    //return;
     onSubmit(data);
     reset({ name: undefined, platform: undefined });
     onClose();

--- a/src/renderer/src/components/StateMachineEditModal.tsx
+++ b/src/renderer/src/components/StateMachineEditModal.tsx
@@ -1,4 +1,5 @@
 import { Controller, UseFormReturn } from 'react-hook-form';
+import { twMerge } from 'tailwind-merge';
 
 import { Modal, Select } from '@renderer/components/UI';
 import { useModelContext } from '@renderer/store/ModelContext';
@@ -20,6 +21,7 @@ interface StateMachineEditModalProps {
   form: UseFormReturn<StateMachineData>;
   platformList: optionType[];
   isDuplicateName: (name: string) => boolean;
+  selectPlatformDisabled: boolean;
 }
 
 // TODO (Roundabout1): наверное стоит перенести этот тип данных в другое место?
@@ -38,6 +40,7 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
   form,
   platformList,
   isDuplicateName,
+  selectPlatformDisabled: selectorDisable,
 }) => {
   const {
     handleSubmit: hookHandleSubmit,
@@ -105,7 +108,7 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
           render={({ field: { onChange, value } }) => (
             <ComponentFormFieldLabel label="Платформа" error={errors.platform?.message}>
               <Select
-                className="w-[250px]"
+                className={twMerge('w-[250px]', selectorDisable && 'opacity-60')}
                 isSearchable={false}
                 placeholder="Выберите платформу..."
                 options={platformList}
@@ -113,6 +116,7 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
                 onChange={(opt) => {
                   onChange(opt?.value);
                 }}
+                isDisabled={selectorDisable}
               />
             </ComponentFormFieldLabel>
           )}

--- a/src/renderer/src/components/StateMachineEditModal.tsx
+++ b/src/renderer/src/components/StateMachineEditModal.tsx
@@ -19,6 +19,7 @@ interface StateMachineEditModalProps {
   onSide: (() => void) | undefined;
   form: UseFormReturn<StateMachineData>;
   platformList: optionType[];
+  isDuplicateName: (name: string) => boolean;
 }
 
 // TODO (Roundabout1): наверное стоит перенести этот тип данных в другое место?
@@ -36,8 +37,15 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
   onSide,
   form,
   platformList,
+  isDuplicateName,
 }) => {
-  const { handleSubmit: hookHandleSubmit, control, reset } = form;
+  const {
+    handleSubmit: hookHandleSubmit,
+    control,
+    reset,
+    setError,
+    formState: { errors },
+  } = form;
   const modelController = useModelContext();
   const editor = modelController.getCurrentCanvas();
 
@@ -47,6 +55,16 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
   };
 
   const handleSubmit = hookHandleSubmit((data) => {
+    if (isDuplicateName(data.name)) {
+      setError('name', { message: 'Имя не должно повторяться' });
+      return;
+    }
+    if (!data.platform) {
+      setError('platform', { message: 'Выберите платформу' });
+      return;
+    }
+    //setError('name', { message: '' });
+    //return;
     onSubmit(data);
     reset({ name: undefined, platform: undefined });
     onClose();
@@ -79,6 +97,7 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
               placeholder="Введите название..."
               onChange={onChange}
               value={value ?? ''}
+              error={errors.name?.message}
             ></ComponentFormFieldLabel>
           )}
         />
@@ -86,7 +105,7 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
           name="platform"
           control={control}
           render={({ field: { onChange, value } }) => (
-            <ComponentFormFieldLabel label="Платформа">
+            <ComponentFormFieldLabel label="Платформа" error={errors.platform?.message}>
               <Select
                 className="w-[250px]"
                 isSearchable={false}

--- a/src/renderer/src/components/StateMachineEditModal.tsx
+++ b/src/renderer/src/components/StateMachineEditModal.tsx
@@ -48,7 +48,7 @@ export const StateMachineEditModal: React.FC<StateMachineEditModalProps> = ({
 
   const handleSubmit = hookHandleSubmit((data) => {
     onSubmit(data);
-    reset({ name: '', platform: '' });
+    reset({ name: undefined, platform: undefined });
     onClose();
   });
 

--- a/src/renderer/src/hooks/useFileOperations.ts
+++ b/src/renderer/src/hooks/useFileOperations.ts
@@ -100,11 +100,7 @@ export const useFileOperations = (args: useFileOperationsArgs) => {
     modelController.files.newFile(idx);
     // schemeModel?.files.newFile(idx);
     clearTabs();
-    openTab({
-      type: 'editor',
-      name: 'editor',
-      canvasId: modelController.model.data.headControllerId,
-    });
+    openTabs();
   };
 
   const handleSaveAsFile = async () => {
@@ -153,8 +149,7 @@ export const useFileOperations = (args: useFileOperationsArgs) => {
       const result = await modelController.files.import(setOpenData);
       if (result) {
         clearTabs();
-        // TODO: Откуда брать CanvasId?
-        openTab({ type: 'editor', name: 'editor', canvasId: '' });
+        openTabs();
       }
     }
   };

--- a/src/renderer/src/hooks/useStateMachines.ts
+++ b/src/renderer/src/hooks/useStateMachines.ts
@@ -22,10 +22,7 @@ export const useStateMachines = () => {
     state.renameTab,
   ]);
   const [idx, setIdx] = useState<string | undefined>(undefined); // индекс текущей машины состояний
-  const [data, setData] = useState<StateMachineData>({
-    name: '',
-    platform: '',
-  });
+  const [data, setData] = useState<StateMachineData | undefined>(undefined);
 
   const [isAddOpen, openAdd, closeAdd] = useModal(false);
   const [isEditOpen, openEdit, editClose] = useModal(false);
@@ -35,6 +32,8 @@ export const useStateMachines = () => {
   const addForm = useForm<StateMachineData>();
 
   const onRequestAddStateMachine = () => {
+    setIdx(undefined);
+    setData(undefined);
     openAdd();
   };
 
@@ -89,10 +88,18 @@ export const useStateMachines = () => {
     editClose();
   };
 
+  /**
+   * Использовать только после вызова {@link onRequestEditStateMachine} или {@link onRequestAddStateMachine}.
+   * @param name имя машины состояний.
+   * @returns true, если имя дублирует имя другой машины состояний или её ID;
+   * false, если имя отсутствует, или оно не дублирует другие имена или ID.
+   */
   const isDuplicateName = (name: string) => {
+    if (!name) return false;
     const machines = [...Object.entries(modelController.model.data.elements.stateMachines)];
-    for (const [, value] of machines) {
-      if (value.name && value.name == name) {
+    for (const [id, value] of machines) {
+      if (id == idx) continue;
+      if ((value.name && value.name == name) || name == id) {
         return true;
       }
     }

--- a/src/renderer/src/hooks/useStateMachines.ts
+++ b/src/renderer/src/hooks/useStateMachines.ts
@@ -56,7 +56,7 @@ export const useStateMachines = () => {
     const sm = { ...emptyStateMachine(), ...data };
     const canvasId = modelController.createStateMachine(smId, sm);
     modelController.model.changeHeadControllerId(canvasId);
-    openTab({ type: 'editor', canvasId: canvasId, name: sm.name ?? canvasId });
+    openTab({ type: 'editor', canvasId: canvasId, name: sm.name ?? smId });
   };
 
   const onEdit = (data: StateMachineData) => {

--- a/src/renderer/src/hooks/useStateMachines.ts
+++ b/src/renderer/src/hooks/useStateMachines.ts
@@ -89,6 +89,16 @@ export const useStateMachines = () => {
     editClose();
   };
 
+  const isDuplicateName = (name: string) => {
+    const machines = [...Object.entries(modelController.model.data.elements.stateMachines)];
+    for (const [, value] of machines) {
+      if (value.name && value.name == name) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   // TODO: swap state machines
   // const onSwapComponents = (name1: string, name2: string) => {
   //   modelController.swapComponents({ smId: currentSm, name1, name2 });
@@ -117,5 +127,6 @@ export const useStateMachines = () => {
     },
     onRequestAddStateMachine,
     onRequestEditStateMachine,
+    isDuplicateName,
   };
 };

--- a/src/renderer/src/hooks/useStateMachines.ts
+++ b/src/renderer/src/hooks/useStateMachines.ts
@@ -51,15 +51,6 @@ export const useStateMachines = () => {
     openEdit();
   };
 
-  const onRequestDeleteStateMachine = (idx: string) => {
-    const stateMachine = model.data.elements.stateMachines[idx];
-    if (!stateMachine) return;
-    const smData = { name: stateMachine.name ?? '', platform: stateMachine.platform };
-    setIdx(idx);
-    setData(smData);
-    openDelete();
-  };
-
   const onAdd = (data: StateMachineData) => {
     const smId = generateId();
     const sm = { ...emptyStateMachine(), ...data };
@@ -119,7 +110,6 @@ export const useStateMachines = () => {
       idx: idx,
     },
     onRequestAddStateMachine,
-    onRequestDeleteStateMachine,
     onRequestEditStateMachine,
   };
 };

--- a/src/renderer/src/hooks/useStateMachines.ts
+++ b/src/renderer/src/hooks/useStateMachines.ts
@@ -15,10 +15,11 @@ export const useStateMachines = () => {
   const model = modelController.model;
 
   // const currentSm = model.useData('', 'currentSm');
-  const [items, openTab, closeTab] = useTabs((state) => [
+  const [items, openTab, closeTab, renameTab] = useTabs((state) => [
     state.items,
     state.openTab,
     state.closeTab,
+    state.renameTab,
   ]);
   const [idx, setIdx] = useState<string | undefined>(undefined); // индекс текущей машины состояний
   const [data, setData] = useState<StateMachineData>({
@@ -56,11 +57,16 @@ export const useStateMachines = () => {
     const sm = { ...emptyStateMachine(), ...data };
     const canvasId = modelController.createStateMachine(smId, sm);
     modelController.model.changeHeadControllerId(canvasId);
-    openTab({ type: 'editor', canvasId: canvasId, name: sm.name ?? smId });
+    openTab({ type: 'editor', canvasId: canvasId, name: sm.name ? sm.name : smId });
   };
 
   const onEdit = (data: StateMachineData) => {
     if (!idx) return;
+    const sm = modelController.model.data.elements.stateMachines[idx];
+    const smName = sm.name ?? '';
+    if (data.name != smName) {
+      renameTab(smName ? smName : idx, data.name ? data.name : idx);
+    }
     modelController.editStateMachine(idx, data);
   };
 

--- a/src/renderer/src/store/useTabs.ts
+++ b/src/renderer/src/store/useTabs.ts
@@ -11,6 +11,7 @@ interface TabsState {
   closeTab: (tabName: string, modelController: ModelController) => void;
   swapTabs: (a: string, b: string) => void;
   clearTabs: () => void;
+  renameTab: (oldName: string, newName: string) => void;
 }
 
 export const useTabs = create<TabsState>((set) => ({
@@ -89,4 +90,17 @@ export const useTabs = create<TabsState>((set) => ({
       items: [],
       activeTab: null,
     })),
+  renameTab: (oldName, newName) =>
+    set(({ items, activeTab }) => {
+      const newItems = [...items];
+      const index = newItems.findIndex(({ name }) => name === oldName);
+      newItems[index].name = newName;
+
+      const newActiveTab = oldName == activeTab ? newName : activeTab;
+
+      return {
+        items: newItems,
+        activeTab: newActiveTab,
+      };
+    }),
 }));


### PR DESCRIPTION
Готово:
- модалка с удалением машины состояний больше не вылезает при нажатии на правую кнопку мыши на компонент, вместо этого открывается вкладка с машиной состояний
- при создании вкладки для машины состояний с пустым названием, для имени вкладки выбирается ID машины состояний, а не ID канваса
- добавлена функция переименования вкладки
- добавлена валидация формы создания/редактирования машины состояний: запрещается создавать машину состояний без платформы или с повторяющимся именем

Проблемы:
- неизвестно, что нужно делать при переключении с платформы "Берлоги" на платформу "Ардуино", так как они используют разные типы компонентов, возможно стоит это запретить. При этом переключение между платформами "Ардуино" или между платформами "Берлога" по-идее должно работать.
- вкладка с первой машиной состояний имеет название "editor", однако это не совпадает с именем или ID машины состояний, из-за чего возникают проблемы, например при нажатии на правую кнопку мыши открывается новая вкладка, но с другим названием, которое соответствует имени или ID машины, что приводит к крашу IDE, при переключении вкладок. Я думаю стоит просто дать какое-нибудь дефолтное название для вкладки и машины состояний.