### PR TITLE
Фикс переименования вкладок

### DIFF
--- a/src/renderer/src/hooks/useStateMachines.ts
+++ b/src/renderer/src/hooks/useStateMachines.ts
@@ -67,7 +67,7 @@ export const useStateMachines = () => {
     const sm = modelController.model.data.elements.stateMachines[idx];
     const smName = sm.name ?? '';
     if (data.name !== smName) {
-      renameTab(smName ?? idx, data.name ?? idx);
+      renameTab(smName ? smName : idx, data.name ? data.name : idx);
     }
     modelController.editStateMachine(idx, data);
   };


### PR DESCRIPTION
Если имя машины состояний отсутствовало, то её невозможно было переименовать.